### PR TITLE
Modify numerous metrics to more closely match best practices

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -14,7 +14,6 @@
 package collector
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -83,14 +82,6 @@ func sliceContains(slice []string, str string) bool {
 		}
 	}
 	return false
-}
-
-func statusToFloat64(data string) float64 {
-	if bytes.Equal([]byte(data), []byte("optimal")) {
-		return 1
-	} else {
-		return 0
-	}
 }
 
 func getRequest(target config.Target, path string, logger log.Logger) ([]byte, error) {

--- a/collector/drive-statistics_test.go
+++ b/collector/drive-statistics_test.go
@@ -76,8 +76,8 @@ func TestDriveStatisticsCollector(t *testing.T) {
 	gatherers := setupGatherer(collector)
 	if val, err := testutil.GatherAndCount(gatherers); err != nil {
 		t.Errorf("Unexpected error: %v", err)
-	} else if val != 32 {
-		t.Errorf("Unexpected collection count %d, expected 32", val)
+	} else if val != 28 {
+		t.Errorf("Unexpected collection count %d, expected 28", val)
 	}
 	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
 		/*

--- a/collector/drives_test.go
+++ b/collector/drives_test.go
@@ -42,10 +42,32 @@ func TestDrivesCollector(t *testing.T) {
 		t.Fatalf("Error loading fixture data: %s", err.Error())
 	}
 	expected := `
-	# HELP eseries_drive_status Drive status, 1=optimal 0=all other states
+	# HELP eseries_drive_status Drive status
 	# TYPE eseries_drive_status gauge
+	eseries_drive_status{slot="53",status="bypassed",systemid="test",tray="0"} 0
+	eseries_drive_status{slot="53",status="dataRelocation",systemid="test",tray="0"} 0
+	eseries_drive_status{slot="53",status="failed",systemid="test",tray="0"} 1
+	eseries_drive_status{slot="53",status="incompatible",systemid="test",tray="0"} 0
+	eseries_drive_status{slot="53",status="optimal",systemid="test",tray="0"} 0
+	eseries_drive_status{slot="53",status="preFailCopy",systemid="test",tray="0"} 0
+	eseries_drive_status{slot="53",status="preFailCopyPending",systemid="test",tray="0"} 0
+	eseries_drive_status{slot="53",status="removed",systemid="test",tray="0"} 0
+	eseries_drive_status{slot="53",status="replaced",systemid="test",tray="0"} 0
+	eseries_drive_status{slot="53",status="unknown",systemid="test",tray="0"} 0
+	eseries_drive_status{slot="53",status="unresponsive",systemid="test",tray="0"} 0
+	eseries_drive_status{slot="53",status="__UNDEFINED",systemid="test",tray="0"} 0
+	eseries_drive_status{slot="58",status="bypassed",systemid="test",tray="0"} 0
+	eseries_drive_status{slot="58",status="dataRelocation",systemid="test",tray="0"} 0
+	eseries_drive_status{slot="58",status="failed",systemid="test",tray="0"} 0
+	eseries_drive_status{slot="58",status="incompatible",systemid="test",tray="0"} 0
 	eseries_drive_status{slot="58",status="optimal",systemid="test",tray="0"} 1
-	eseries_drive_status{slot="53",status="failed",systemid="test",tray="0"} 0
+	eseries_drive_status{slot="58",status="preFailCopy",systemid="test",tray="0"} 0
+	eseries_drive_status{slot="58",status="preFailCopyPending",systemid="test",tray="0"} 0
+	eseries_drive_status{slot="58",status="removed",systemid="test",tray="0"} 0
+	eseries_drive_status{slot="58",status="replaced",systemid="test",tray="0"} 0
+	eseries_drive_status{slot="58",status="unknown",systemid="test",tray="0"} 0
+	eseries_drive_status{slot="58",status="unresponsive",systemid="test",tray="0"} 0
+	eseries_drive_status{slot="58",status="__UNDEFINED",systemid="test",tray="0"} 0
 	# HELP eseries_exporter_collect_error Indicates if error has occurred during collection
 	# TYPE eseries_exporter_collect_error gauge
 	eseries_exporter_collect_error{collector="drives"} 0
@@ -68,8 +90,8 @@ func TestDrivesCollector(t *testing.T) {
 	gatherers := setupGatherer(collector)
 	if val, err := testutil.GatherAndCount(gatherers); err != nil {
 		t.Errorf("Unexpected error: %v", err)
-	} else if val != 4 {
-		t.Errorf("Unexpected collection count %d, expected 4", val)
+	} else if val != 26 {
+		t.Errorf("Unexpected collection count %d, expected 26", val)
 	}
 	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
 		"eseries_drive_status", "eseries_exporter_collect_error"); err != nil {

--- a/collector/storage-systems_test.go
+++ b/collector/storage-systems_test.go
@@ -47,7 +47,14 @@ func TestStorageSystemCollector(t *testing.T) {
 	eseries_exporter_collect_error{collector="storage-systems"} 0
 	# HELP eseries_storage_system_status Storage System status, 1=optimal 0=all other states
 	# TYPE eseries_storage_system_status gauge
+	eseries_storage_system_status{id="e5660-01",status="lockDown"} 0
+	eseries_storage_system_status{id="e5660-01",status="needsAttn"} 0
+	eseries_storage_system_status{id="e5660-01",status="neverContacted"} 0
+	eseries_storage_system_status{id="e5660-01",status="newDevice"} 0
+	eseries_storage_system_status{id="e5660-01",status="offline"} 0
 	eseries_storage_system_status{id="e5660-01",status="optimal"} 1
+	eseries_storage_system_status{id="e5660-01",status="removed"} 0
+	eseries_storage_system_status{id="e5660-01",status="unknown"} 0
 	`
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		_, _ = rw.Write(fixtureData)
@@ -67,8 +74,8 @@ func TestStorageSystemCollector(t *testing.T) {
 	gatherers := setupGatherer(collector)
 	if val, err := testutil.GatherAndCount(gatherers); err != nil {
 		t.Errorf("Unexpected error: %v", err)
-	} else if val != 3 {
-		t.Errorf("Unexpected collection count %d, expected 3", val)
+	} else if val != 10 {
+		t.Errorf("Unexpected collection count %d, expected 10", val)
 	}
 	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
 		"eseries_storage_system_status", "eseries_exporter_collect_error"); err != nil {

--- a/collector/system-statistics_test.go
+++ b/collector/system-statistics_test.go
@@ -67,8 +67,8 @@ func TestSystemStatisticsCollector(t *testing.T) {
 	gatherers := setupGatherer(collector)
 	if val, err := testutil.GatherAndCount(gatherers); err != nil {
 		t.Errorf("Unexpected error: %v", err)
-	} else if val != 26 {
-		t.Errorf("Unexpected collection count %d, expected 26", val)
+	} else if val != 24 {
+		t.Errorf("Unexpected collection count %d, expected 24", val)
 	}
 	if err := testutil.GatherAndCompare(gatherers, strings.NewReader(expected),
 		/*


### PR DESCRIPTION
Improve status metrics to always have all possible statuses and set 1 for current status

Remove metrics
* eseries_drive_read_ops
* eseries_drive_write_ops
* eseries_system_read_ops
* eseries_system_write_ops

Rename metrics to change units of measurement
* eseries_drive_combined_response_time_milliseconds to eseries_drive_combined_response_time_seconds
* eseries_drive_read_response_time_milliseconds to eseries_drive_read_response_time_seconds
* eseries_drive_write_response_time_milliseconds to eseries_drive_write_response_time_seconds
* eseries_drive_combined_throughput_mb_per_second to eseries_drive_combined_throughput_bytes_per_second
* eseries_drive_read_throughput_mb_per_second to eseries_drive_read_throughput_bytes_per_second
* eseries_drive_write_throughput_mb_per_second to eseries_drive_write_throughput_bytes_per_second
* eseries_system_combined_hit_response_time_milliseconds to eseries_system_combined_hit_response_time_seconds
* eseries_system_combined_response_time_milliseconds to eseries_system_combined_response_time_seconds
* eseries_system_read_hit_response_time_milliseconds to eseries_system_read_hit_response_time_seconds
* eseries_system_read_response_time_milliseconds to eseries_system_read_response_time_seconds
* eseries_system_write_hit_response_time_milliseconds to eseries_system_write_hit_response_time_seconds
* eseries_system_write_response_time_milliseconds to eseries_system_write_response_time_seconds
* eseries_system_combined_throughput_mb_per_second to eseries_system_combined_throughput_bytes_per_second
* eseries_system_read_throughput_mb_per_second to eseries_system_read_throughput_bytes_per_second
* eseries_system_write_throughput_mb_per_second to eseries_system_write_throughput_bytes_per_second